### PR TITLE
Release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Release 0.4.1
+
+### Bugfix
+- Did not convert data of registered events to strings before trying to publish them via MQTT
+
 ## Release 0.4.0
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## Release 0.4.1
 
+### Improvements
+- Updated docu and added "Known issues" in README that data of registered events to be forwarded via MQTT are always published as converted data type "string".
+
 ### Bugfix
 - Did not convert data of registered events to strings before trying to publish them via MQTT
 

--- a/CSK_Module_MQTTClient/project.mf.xml
+++ b/CSK_Module_MQTTClient/project.mf.xml
@@ -417,7 +417,7 @@ Configure a WillMessage via "setWillMessageConfig" (via script) or "setWillMessa
             </serves>
         </crown>
         <meta key="author">SICK AG</meta>
-        <meta key="version">0.4.0</meta>
+        <meta key="version">0.4.1</meta>
         <meta key="priority">low</meta>
         <meta key="copy-protected">false</meta>
         <meta key="read-protected">false</meta>

--- a/CSK_Module_MQTTClient/scripts/Communication/MQTTClient/MQTTClient_Model.lua
+++ b/CSK_Module_MQTTClient/scripts/Communication/MQTTClient/MQTTClient_Model.lua
@@ -155,9 +155,9 @@ end
 MQTTClient.register(mqttClient_Model.mqttClient, 'OnReceive', handleOnReceive)
 
 local function publish(topic, data, qos, retain)
-  _G.logger:info(nameOfModule .. ": Publish data '" .. data .. "' to topic '" .. topic .. "' with QoS '" .. qos .. "' and '" .. retain .. "'")
-  addMessageLog("Publish data '" .. data .. "' to topic '" .. topic .. "' with QoS '" .. qos .. "' and '" .. retain .. "'")
-  MQTTClient.publish(mqttClient_Model.mqttClient, topic, data, qos, retain)
+  _G.logger:info(nameOfModule .. ": Publish data '" .. tostring(data) .. "' to topic '" .. topic .. "' with QoS '" .. qos .. "' and '" .. retain .. "'")
+  addMessageLog("Publish data '" .. tostring(data) .. "' to topic '" .. topic .. "' with QoS '" .. qos .. "' and '" .. retain .. "'")
+  MQTTClient.publish(mqttClient_Model.mqttClient, topic, tostring(data), qos, retain)
 end
 Script.serveFunction('CSK_MQTTClient.publish', publish)
 mqttClient_Model.publish = publish

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Module to provide MQTT client functionality.
 The app includes an intuitive GUI to setup the MQTTClient configuration.  
 For further information check out the [documentation](https://raw.githack.com/SICKAppSpaceCodingStarterKit/CSK_Module_MQTTClient/main/docu/CSK_Module_MQTTClient.html) in the folder "docu".
 
+## Known issues
+
+Data of registered events to be forwarded via MQTT are always published as converted data type "string".
+
 ## Information
 
 Tested on:

--- a/docu/CSK_Module_MQTTClient.html
+++ b/docu/CSK_Module_MQTTClient.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.12">
 <meta name="author" content="SICK AG">
-<title>Documentation - CSK_Module_MQTTClient 0.4.0</title>
+<title>Documentation - CSK_Module_MQTTClient 0.4.1</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 <style>
 /* Stylesheet for CodeRay to match GitHub theme | MIT License | http://foundation.zurb.com */
@@ -615,11 +615,11 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </head>
 <body class="article toc2 toc-left">
 <div id="header">
-<h1>Documentation - CSK_Module_MQTTClient 0.4.0</h1>
+<h1>Documentation - CSK_Module_MQTTClient 0.4.1</h1>
 <div class="details">
 <span id="author" class="author">SICK AG</span><br>
-<span id="revnumber">version 0.4.0,</span>
-<span id="revdate">2023-06-15</span>
+<span id="revnumber">version 0.4.1,</span>
+<span id="revdate">2023-09-19</span>
 </div>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
@@ -765,11 +765,11 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Version</p></th>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0.4.0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0.4.1</p></td>
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Date</p></th>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2023-06-15</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-09-19</p></td>
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Author</p></th>
@@ -5286,8 +5286,8 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </div>
 <div id="footer">
 <div id="footer-text">
-Version 0.4.0<br>
-Last updated 2023-06-15 09:03:01 +0200
+Version 0.4.1<br>
+Last updated 2023-09-19 10:40:06 +0200
 </div>
 </div>
 <script type="text/javascript">

--- a/docu/CSK_Module_MQTTClient.html
+++ b/docu/CSK_Module_MQTTClient.html
@@ -830,7 +830,7 @@ It is also possible to get the MQTTClient handle via "getMQTTHandle" to use this
 <strong>4) Publish</strong><br>
 It is possible to publish MQTT messages via "publish" (via script) or "publishViaUI (via UI) to use preset values (check "presetPublish&#8230;&#8203;"-functions)<br>
 Additionally it is possible to configure the module to listen / wait for specific events of other modules/apps and to forward their content to predefined topics with predefined QoS/Retain.<br>
-This can be used e.g. to listen to "OtherModule.OnNewResult"-events and to forward the results via MQTT.<br>
+This can be used e.g. to listen to "OtherModule.OnNewResult"-events and to forward the results via MQTT (data will be forwarded to data type 'string').<br>
 To do so make use of "addPublishEvent" (via script) or the "presetPublish"-functions (incl. "presetPublishEvent") and "addPublishEventViaUI".<br>
 <br>
 <strong>5) WillMessage</strong><br>
@@ -1124,7 +1124,7 @@ Configure a WillMessage via "setWillMessageConfig" (via script) or "setWillMessa
 <div class="sect5">
 <h6 id="_short_description_3">Short description</h6>
 <div class="paragraph">
-<p>Function to add an event to listen to and forward content if notified with configured MQTT publish message.</p>
+<p>Function to add an event to listen to and forward content (as string) if notified with configured MQTT publish message.</p>
 </div>
 </div>
 <div class="sect5">
@@ -1188,7 +1188,7 @@ Configure a WillMessage via "setWillMessageConfig" (via script) or "setWillMessa
 <div class="sect5">
 <h6 id="_short_description_4">Short description</h6>
 <div class="paragraph">
-<p>Function to add a preset event with preset configuration (topic, QoS, Retain) to listen to and to forward content via MQTT publish.</p>
+<p>Function to add a preset event with preset configuration (topic, QoS, Retain) to listen to and to forward content (as string) via MQTT publish.</p>
 </div>
 </div>
 <div class="sect5">
@@ -5287,7 +5287,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div id="footer">
 <div id="footer-text">
 Version 0.4.1<br>
-Last updated 2023-09-19 10:40:06 +0200
+Last updated 2023-09-19 11:19:46 +0200
 </div>
 </div>
 <script type="text/javascript">


### PR DESCRIPTION
# Version 0.4.1

## Bugfix
- Did not convert data of registered events to strings before trying to publish them via MQTT

## Following tasks were checked

- [x] Module is coded and structured according to the "Developing guideline for modules" described within the CSK documentation
- [x] All functions/events/parameters are documented within the manifest documentation
- [x] The manifest description of the main CROWN includes main information about the purpose of the module and how to use it in general
- [x] API docu based on the manifest was created and stored within the "docu"-folder of the repository
- [x] Internal LUA code documentation exists for variables and non served functions
- [x] All relevant infos are logged via the SharedLogger 'ModuleLogger'
- [x] Module supports persistent data feature based on 'CSK_Module_PersistentData'
- [x] Module supports user management based on 'CSK_Module_UserManagement'
- [x] No open "ToDos" within the code or at least clearly explained comments why they exist...
- [x] "Version" key in app manifest was updated following semantic versioning (and use '0.x.y' for test / experimental modules which are not yet ready to be officially released)
- [x] Meaningful IDs used for UI elements
- [x] Module was tested on an AppSpace device (at least on SICK AppEngine) with no error message
- [x] README.md is up to date (incl. info of device + firmware the module was tested with)
- [x] CHANGELOG.md is up to date
