### PR TITLE
Version 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 - Changed a couple of misleading labels for MQTTS in UI
 
 ### Bugfix
-- Bug of multiple functions call by the same event when topic of the event is changed. Solved by deregistering from event if the topic of the event is changed
+- Bug of multiple function calls by the same event when topic of the event is changed. Solved by deregistering from event if the topic of the event is changed
 - 'passwords' changed to 'password' as the parameter is called mqttClient_Model.parameters.password
 
 ## Release 0.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Release 1.0.0
+
+### Improvements
+- Reconnection timer of 5 seconds in case the connection is lost (broker is rebooted)
+- Showing in the message log if connection/reconnection failed
+- Changed a couple of misleading labels for MQTTS in UI
+
+### Bugfix
+- Bug of multiple functions call by the same event when topic of the event is changed. Solved by deregistering from event if the topic of the event is changed
+- 'passwords' changed to 'password' as the parameter is called mqttClient_Model.parameters.password
+
 ## Release 0.4.1
 
 ### Improvements

--- a/CSK_Module_MQTTClient/pages/pages/CSK_Module_MQTTClient/CSK_Module_MQTTClient.html
+++ b/CSK_Module_MQTTClient/pages/pages/CSK_Module_MQTTClient/CSK_Module_MQTTClient.html
@@ -58,11 +58,11 @@
 										<layout-row id="RowLayout8"
 											style="justify-content: space-between; align-items: center">
 											<layout-column id="ColumnLayout14" style="align-items: stretch">
-												<davinci-value-display id="VD_BrokerIP" value="Broker IP:">
+												<davinci-value-display id="VD_BrokerURL" value="Broker URL:">
 												</davinci-value-display>
 											</layout-column>
 											<layout-column id="ColumnLayout18" style="align-items: stretch">
-												<davinci-text-field id="TF_BrokerIP" type="text">
+												<davinci-text-field id="TF_BrokerURL" type="text">
 												<crown-edpws-binding property="value"
 													name="CSK_MQTTClient/OnNewBrokerIP" update-on-resume>
 												</crown-edpws-binding>
@@ -374,7 +374,7 @@
 												<layout-row id="RowLayout40" style="justify-content: space-between">
 												<layout-column id="ColumnLayout54" style="align-items: stretch">
 												<davinci-value-display id="VD_CABundle"
-													value="Use Client Certificate:">
+													value="Use server certificate authority (CA) bundle:">
 												</davinci-value-display>
 												</layout-column>
 												<layout-column id="ColumnLayout55" style="align-items: stretch">

--- a/CSK_Module_MQTTClient/project.mf.xml
+++ b/CSK_Module_MQTTClient/project.mf.xml
@@ -417,7 +417,7 @@ Configure a WillMessage via "setWillMessageConfig" (via script) or "setWillMessa
             </serves>
         </crown>
         <meta key="author">SICK AG</meta>
-        <meta key="version">0.4.1</meta>
+        <meta key="version">1.0.0</meta>
         <meta key="priority">low</meta>
         <meta key="copy-protected">false</meta>
         <meta key="read-protected">false</meta>

--- a/CSK_Module_MQTTClient/project.mf.xml
+++ b/CSK_Module_MQTTClient/project.mf.xml
@@ -23,7 +23,7 @@ It is also possible to get the MQTTClient handle via "getMQTTHandle" to use this
 **4) Publish** +
 It is possible to publish MQTT messages via "publish" (via script) or "publishViaUI (via UI) to use preset values (check "presetPublish..."-functions) +
 Additionally it is possible to configure the module to listen / wait for specific events of other modules/apps and to forward their content to predefined topics with predefined QoS/Retain. +
-This can be used e.g. to listen to "OtherModule.OnNewResult"-events and to forward the results via MQTT. +
+This can be used e.g. to listen to "OtherModule.OnNewResult"-events and to forward the results via MQTT (data will be forwarded to data type 'string'). +
 To do so make use of "addPublishEvent" (via script) or the "presetPublish"-functions (incl. "presetPublishEvent") and "addPublishEventViaUI". +
 {empty} +
 **5) WillMessage** +
@@ -308,7 +308,7 @@ Configure a WillMessage via "setWillMessageConfig" (via script) or "setWillMessa
                     <desc>Function to unsubscribe from preselected topic via UI (see "selectSubscriptionViaUI").</desc>
                 </function>
                 <function name="addPublishEvent">
-                    <desc>Function to add an event to listen to and forward content if notified with configured MQTT publish message.</desc>
+                    <desc>Function to add an event to listen to and forward content (as string) if notified with configured MQTT publish message.</desc>
                     <param desc="Name of event to register (event with one parameter expected)." multiplicity="1" name="event" type="string"/>
                     <param desc="Data content of the event will be publsihed to this MQTT topic." multiplicity="1" name="topic" type="string"/>
                     <param desc="QoS of publish message." multiplicity="1" name="qos" ref="CSK_MQTTClient.QOS" type="enum"/>
@@ -323,7 +323,7 @@ Configure a WillMessage via "setWillMessageConfig" (via script) or "setWillMessa
                     <param desc="Name of event" multiplicity="1" name="name" type="string"/>
                 </function>
                 <function name="addPublishEventViaUI">
-                    <desc>Function to add a preset event with preset configuration (topic, QoS, Retain) to listen to and to forward content via MQTT publish.</desc>
+                    <desc>Function to add a preset event with preset configuration (topic, QoS, Retain) to listen to and to forward content (as string) via MQTT publish.</desc>
                 </function>
                 <function name="selectPublishEvent">
                     <desc>Function to select event of list to publish via UI.</desc>

--- a/CSK_Module_MQTTClient/scripts/Communication/MQTTClient/MQTTClient_Controller.lua
+++ b/CSK_Module_MQTTClient/scripts/Communication/MQTTClient/MQTTClient_Controller.lua
@@ -560,7 +560,7 @@ local function addPublishEvent(event, topic, qos, retain)
 
   Script.notifyEvent("MQTTClient_OnNewStatusPublishEventList", mqttClient_Model.helperFuncs.createJsonListPublishEvents(mqttClient_Model.parameters.publishEvents))
 
-  createInternalPublishFunctions(event, topic, qos, retain)
+  createInternalPublishFunctions(event)
 
 end
 Script.serveFunction('CSK_MQTTClient.addPublishEvent', addPublishEvent)
@@ -677,7 +677,7 @@ local function loadParameters()
 
       -- Configured/activated with new loaded data
       for key in pairs(mqttClient_Model.parameters.publishEvents.topic) do
-        createInternalPublishFunctions(key, mqttClient_Model.parameters.publishEvents.topic[key], mqttClient_Model.parameters.publishEvents.qos[key], mqttClient_Model.parameters.publishEvents.retain[key])
+        createInternalPublishFunctions(key)
       end
       connectMQTT(mqttClient_Model.parameters.connect)
 

--- a/CSK_Module_MQTTClient/scripts/Communication/MQTTClient/MQTTClient_Controller.lua
+++ b/CSK_Module_MQTTClient/scripts/Communication/MQTTClient/MQTTClient_Controller.lua
@@ -222,7 +222,7 @@ local function connectMQTT(status)
     end
     MQTTClient.setKeepAliveInterval(mqttClient_Model.mqttClient, mqttClient_Model.parameters.keepAliveInterval)
     if mqttClient_Model.parameters.useCredentials then
-      MQTTClient.setUserCredentials(mqttClient_Model.mqttClient, mqttClient_Model.parameters.username, Cipher.AES.decrypt(mqttClient_Model.parameters.passwords, mqttClient_Model.key))
+      MQTTClient.setUserCredentials(mqttClient_Model.mqttClient, mqttClient_Model.parameters.username, Cipher.AES.decrypt(mqttClient_Model.parameters.password, mqttClient_Model.key))
     end
     if mqttClient_Model.parameters.useWillMessage then
       MQTTClient.setWillMessage(mqttClient_Model.mqttClient, mqttClient_Model.parameters.willMessageTopic, mqttClient_Model.parameters.willMessageData, mqttClient_Model.parameters.willMessageQOS, mqttClient_Model.parameters.willMessageRetain)
@@ -249,10 +249,14 @@ local function connectMQTT(status)
         MQTTClient.setCABundle(mqttClient_Model.mqttClient, mqttClient_Model.parameters.caBundlePath)
       end
     end
-
+    mqttClient_Model.reconnectionTimer:start()
     MQTTClient.connect(mqttClient_Model.mqttClient, mqttClient_Model.parameters.connectionTimeout)
+    if mqttClient_Model.mqttClient:isConnected() == false then
+      mqttClient_Model.addMessageLog("Connection failed")
+    end
   else
     MQTTClient.disconnect(mqttClient_Model.mqttClient)
+    mqttClient_Model.reconnectionTimer:stop()
   end
 end
 Script.serveFunction('CSK_MQTTClient.connectMQTT', connectMQTT)
@@ -331,7 +335,7 @@ Script.serveFunction('CSK_MQTTClient.setUsername', setUsername)
 
 local function setPassword(password)
   _G.logger:info(nameOfModule .. ": Set password.")
-  mqttClient_Model.parameters.passwords = Cipher.AES.encrypt(password, mqttClient_Model.key)
+  mqttClient_Model.parameters.password = Cipher.AES.encrypt(password, mqttClient_Model.key)
 end
 Script.serveFunction('CSK_MQTTClient.setPassword', setPassword)
 
@@ -339,7 +343,7 @@ local function setUseCredentials(status)
   _G.logger:info(nameOfModule .. ": Set usage of credentials to " .. tostring(status))
   mqttClient_Model.parameters.useCredentials = status
   if status then
-    MQTTClient.setUserCredentials(mqttClient_Model.mqttClient, mqttClient_Model.parameters.username, Cipher.AES.decrypt(mqttClient_Model.parameters.passwords, mqttClient_Model.key))
+    MQTTClient.setUserCredentials(mqttClient_Model.mqttClient, mqttClient_Model.parameters.username, Cipher.AES.decrypt(mqttClient_Model.parameters.password, mqttClient_Model.key))
   end
 end
 Script.serveFunction('CSK_MQTTClient.setUseCredentials', setUseCredentials)
@@ -522,10 +526,7 @@ Script.serveFunction('CSK_MQTTClient.presetPublishEvent', presetPublishEvent)
 
 --- Function to create internal publish functions
 ---@param event string Name of event to register (event with one parameter expected)
----@param topic string Data content of the event will be publsihed to this MQTT topic
----@param qos string QoS of publish message
----@param retain string Retain option of the publish
-local function createInternalPublishFunctions(event, topic, qos, retain)
+local function createInternalPublishFunctions(event)
 
   local function triggerPublish(event, data)
     if mqttClient_Model.isConnected then
@@ -541,7 +542,7 @@ local function createInternalPublishFunctions(event, topic, qos, retain)
   mqttClient_Model.publishEventsFunctions[event] = forwardContent
 
   if Script.isServedAsEvent(event) then
-    _G.logger:info(nameOfModule .. ": Register to event '" .. event .. "' to forward its content via MQTT publish on topic '" .. topic .. "'")
+    _G.logger:info(nameOfModule .. ": Register to event '" .. event .. "' to forward its content via MQTT publish on topic '" .. mqttClient_Model.parameters.publishEvents.topic[event] .. "'")
     Script.register(event, mqttClient_Model.publishEventsFunctions[event])
   else
     _G.logger:info(nameOfModule .. ": Not possible to register to event '" .. event .. "' as it seems not to be available.")
@@ -549,6 +550,10 @@ local function createInternalPublishFunctions(event, topic, qos, retain)
 end
 
 local function addPublishEvent(event, topic, qos, retain)
+  if mqttClient_Model.publishEventsFunctions[event] then
+    Script.deregister(event, mqttClient_Model.publishEventsFunctions[event])
+    mqttClient_Model.publishEventsFunctions[event] = nil
+  end
   mqttClient_Model.parameters.publishEvents.topic[event] = topic
   mqttClient_Model.parameters.publishEvents.qos[event] = qos
   mqttClient_Model.parameters.publishEvents.retain[event] = retain

--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ Data of registered events to be forwarded via MQTT are always published as conve
 
 Tested on:
 
-1. SIM1012        - Firmware 2.2.0, 2.4.1
-2. SICK AppEngine - Firmware 1.3.2, 1.5.0
-3. TDC-E          - L4M 2023.1
+|Device|Firmware version|Module version|
+|--|--|--|
+|SIM1012|V2.4.1|v1.0.0|
+|SIM1012|V2.2.0|v0.4.1|
+|SICK AppEngine|V1.5.0|v1.0.0|
+|SICK AppEngine|V1.3.2|v0.4.1|
+|TDC-E|L4M 2023.1|v0.4.1|
 
 This module is part of the SICK AppSpace Coding Starter Kit developing approach.  
 It is programmed in an object oriented way. Some of these modules use kind of "classes" in Lua to make it possible to reuse code / classes in other projects.  

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Data of registered events to be forwarded via MQTT are always published as conve
 
 Tested on:
 
-1. SIM1012        - Firmware 2.2.0
-2. SICK AppEngine - Firmware 1.3.2
+1. SIM1012        - Firmware 2.2.0, 2.4.1
+2. SICK AppEngine - Firmware 1.3.2, 1.5.0
 3. TDC-E          - L4M 2023.1
 
 This module is part of the SICK AppSpace Coding Starter Kit developing approach.  

--- a/docu/CSK_Module_MQTTClient.html
+++ b/docu/CSK_Module_MQTTClient.html
@@ -619,7 +619,7 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 <div class="details">
 <span id="author" class="author">SICK AG</span><br>
 <span id="revnumber">version 1.0.0,</span>
-<span id="revdate">2024-02-29</span>
+<span id="revdate">2024-03-20</span>
 </div>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
@@ -769,7 +769,7 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Date</p></th>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-02-29</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-03-20</p></td>
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Author</p></th>
@@ -830,7 +830,7 @@ It is also possible to get the MQTTClient handle via "getMQTTHandle" to use this
 <strong>4) Publish</strong><br>
 It is possible to publish MQTT messages via "publish" (via script) or "publishViaUI (via UI) to use preset values (check "presetPublish&#8230;&#8203;"-functions)<br>
 Additionally it is possible to configure the module to listen / wait for specific events of other modules/apps and to forward their content to predefined topics with predefined QoS/Retain.<br>
-This can be used e.g. to listen to "OtherModule.OnNewResult"-events and to forward the results via MQTT.<br>
+This can be used e.g. to listen to "OtherModule.OnNewResult"-events and to forward the results via MQTT (data will be forwarded to data type 'string').<br>
 To do so make use of "addPublishEvent" (via script) or the "presetPublish"-functions (incl. "presetPublishEvent") and "addPublishEventViaUI".<br>
 <br>
 <strong>5) WillMessage</strong><br>
@@ -1124,7 +1124,7 @@ Configure a WillMessage via "setWillMessageConfig" (via script) or "setWillMessa
 <div class="sect5">
 <h6 id="_short_description_3">Short description</h6>
 <div class="paragraph">
-<p>Function to add an event to listen to and forward content if notified with configured MQTT publish message.</p>
+<p>Function to add an event to listen to and forward content (as string) if notified with configured MQTT publish message.</p>
 </div>
 </div>
 <div class="sect5">
@@ -1188,7 +1188,7 @@ Configure a WillMessage via "setWillMessageConfig" (via script) or "setWillMessa
 <div class="sect5">
 <h6 id="_short_description_4">Short description</h6>
 <div class="paragraph">
-<p>Function to add a preset event with preset configuration (topic, QoS, Retain) to listen to and to forward content via MQTT publish.</p>
+<p>Function to add a preset event with preset configuration (topic, QoS, Retain) to listen to and to forward content (as string) via MQTT publish.</p>
 </div>
 </div>
 <div class="sect5">
@@ -5287,7 +5287,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div id="footer">
 <div id="footer-text">
 Version 1.0.0<br>
-Last updated 2024-02-29 10:14:56 +0100
+Last updated 2024-03-20 10:53:00 +0100
 </div>
 </div>
 <script type="text/javascript">

--- a/docu/CSK_Module_MQTTClient.html
+++ b/docu/CSK_Module_MQTTClient.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.12">
 <meta name="author" content="SICK AG">
-<title>Documentation - CSK_Module_MQTTClient 0.4.1</title>
+<title>Documentation - CSK_Module_MQTTClient 1.0.0</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 <style>
 /* Stylesheet for CodeRay to match GitHub theme | MIT License | http://foundation.zurb.com */
@@ -615,11 +615,11 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </head>
 <body class="article toc2 toc-left">
 <div id="header">
-<h1>Documentation - CSK_Module_MQTTClient 0.4.1</h1>
+<h1>Documentation - CSK_Module_MQTTClient 1.0.0</h1>
 <div class="details">
 <span id="author" class="author">SICK AG</span><br>
-<span id="revnumber">version 0.4.1,</span>
-<span id="revdate">2023-09-19</span>
+<span id="revnumber">version 1.0.0,</span>
+<span id="revdate">2024-02-29</span>
 </div>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
@@ -765,11 +765,11 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Version</p></th>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0.4.1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1.0.0</p></td>
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Date</p></th>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2023-09-19</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-02-29</p></td>
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Author</p></th>
@@ -830,7 +830,7 @@ It is also possible to get the MQTTClient handle via "getMQTTHandle" to use this
 <strong>4) Publish</strong><br>
 It is possible to publish MQTT messages via "publish" (via script) or "publishViaUI (via UI) to use preset values (check "presetPublish&#8230;&#8203;"-functions)<br>
 Additionally it is possible to configure the module to listen / wait for specific events of other modules/apps and to forward their content to predefined topics with predefined QoS/Retain.<br>
-This can be used e.g. to listen to "OtherModule.OnNewResult"-events and to forward the results via MQTT (data will be forwarded to data type 'string').<br>
+This can be used e.g. to listen to "OtherModule.OnNewResult"-events and to forward the results via MQTT.<br>
 To do so make use of "addPublishEvent" (via script) or the "presetPublish"-functions (incl. "presetPublishEvent") and "addPublishEventViaUI".<br>
 <br>
 <strong>5) WillMessage</strong><br>
@@ -1124,7 +1124,7 @@ Configure a WillMessage via "setWillMessageConfig" (via script) or "setWillMessa
 <div class="sect5">
 <h6 id="_short_description_3">Short description</h6>
 <div class="paragraph">
-<p>Function to add an event to listen to and forward content (as string) if notified with configured MQTT publish message.</p>
+<p>Function to add an event to listen to and forward content if notified with configured MQTT publish message.</p>
 </div>
 </div>
 <div class="sect5">
@@ -1188,7 +1188,7 @@ Configure a WillMessage via "setWillMessageConfig" (via script) or "setWillMessa
 <div class="sect5">
 <h6 id="_short_description_4">Short description</h6>
 <div class="paragraph">
-<p>Function to add a preset event with preset configuration (topic, QoS, Retain) to listen to and to forward content (as string) via MQTT publish.</p>
+<p>Function to add a preset event with preset configuration (topic, QoS, Retain) to listen to and to forward content via MQTT publish.</p>
 </div>
 </div>
 <div class="sect5">
@@ -5286,8 +5286,8 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </div>
 <div id="footer">
 <div id="footer-text">
-Version 0.4.1<br>
-Last updated 2023-09-19 11:19:46 +0200
+Version 1.0.0<br>
+Last updated 2024-02-29 10:14:56 +0100
 </div>
 </div>
 <script type="text/javascript">


### PR DESCRIPTION
# Version 1.0.0

## Improvements
- Reconnection timer of 5 seconds in case the connection is lost (broker is rebooted)
- Showing in the message log if connection/reconnection failed
- Changed a couple of misleading labels for MQTTS in UI

## Bugfix
- Bug of multiple functions call by the same event when topic of the event is changed. Solved by deregistering from event if the topic of the event is changed
- 'passwords' changed to 'password' as the parameter is called mqttClient_Model.parameters.password

## Following tasks were checked

- [x] Module is coded and structured according to the "Developing guideline for modules" described within the CSK documentation
- [x] All functions/events/parameters are documented within the manifest documentation
- [x] The manifest description of the main CROWN includes main information about the purpose of the module and how to use it in general
- [x] API docu based on the manifest was created and stored within the "docu"-folder of the repository
- [x] Internal LUA code documentation exists for variables and non served functions
- [x] All relevant infos are logged via the SharedLogger 'ModuleLogger'
- [x] Module supports persistent data feature based on 'CSK_Module_PersistentData'
- [x] Module supports user management based on 'CSK_Module_UserManagement'
- [x] No open "ToDos" within the code or at least clearly explained comments why they exist...
- [x] "Version" key in app manifest was updated following semantic versioning (and use '0.x.y' for test / experimental modules which are not yet ready to be officially released)
- [x] Meaningful IDs used for UI elements
- [x] Module was tested on an AppSpace device (at least on SICK AppEngine) with no error message
- [x] README.md is up to date (incl. info of device + firmware the module was tested with)
- [x] CHANGELOG.md is up to date
